### PR TITLE
Removed type: module for better node support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "type": "git",
     "url": "git+https://github.com/H2D2-Design/h2d2-shopicons.git"
   },
-  "type": "module",
   "author": "naltatis",
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
This property leads to errors in certain scenarios. E.g. when using the library in https://histoire.dev